### PR TITLE
過去シフトプラン参照機能の実装

### DIFF
--- a/backend/app/models/schemas.py
+++ b/backend/app/models/schemas.py
@@ -640,3 +640,36 @@ class ShiftPlanImportResponse(BaseModel):
     """作成されたShiftAssignment件数."""
     skipped_worker_ids: list[str]
     """存在しない社員番号のためスキップされたワーカー識別子のリスト."""
+
+
+class ShiftAssignmentDetail(BaseModel):
+    """ShiftAssignment詳細スキーマ（ShiftPlanDetail内で使用）."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    worker_id: uuid.UUID
+    is_manual_override: bool
+
+
+class ShiftSlotDetail(BaseModel):
+    """ShiftSlot詳細スキーマ（ShiftPlanDetail内で使用）."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    date: datetime
+    slot_type: SlotTypeEnum
+    assignments: list[ShiftAssignmentDetail] = []
+
+
+class ShiftPlanDetailResponse(BaseModel):
+    """ShiftPlan詳細レスポンススキーマ（スロット・アサイン情報を含む）."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    title: str
+    target_year_month: str
+    status: PlanStatusEnum
+    slots: list[ShiftSlotDetail] = []

--- a/backend/app/routers/shift_plans.py
+++ b/backend/app/routers/shift_plans.py
@@ -5,13 +5,13 @@
 過去シフトデータの一括インポートエンドポイントを提供する。
 """
 
-from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, Form, HTTPException, Query, UploadFile, status
 from sqlmodel import Session
 
 from app.db import get_session
 from app.dependencies import get_tenant_id
 from app.models.models import PlanStatusEnum
-from app.models.schemas import ShiftPlanImportResponse
+from app.models.schemas import ShiftPlanDetailResponse, ShiftPlanImportResponse
 from app.services import shift_plan_import_service
 
 router = APIRouter(prefix="/api/shift-plans", tags=["shift-plans"])
@@ -93,6 +93,33 @@ async def import_shift_plan(
         content_type=content_type_hint,
         plan_status=plan_status,
         created_by=created_by,
+    )
+
+
+@router.get("/", response_model=ShiftPlanDetailResponse | None)
+def get_shift_plan(
+    year_month: str = Query(
+        ...,
+        description="対象年月（YYYY-MM形式）。例: '2025-06'",
+        pattern=r"^\d{4}-\d{2}$",
+    ),
+    tenant_id: str = Depends(get_tenant_id),
+    session: Session = Depends(get_session),
+) -> ShiftPlanDetailResponse | None:
+    """対象年月のシフトプランをスロット・アサイン情報込みで返す.
+
+    該当するプランが存在しない場合は null を返す。
+
+    Args:
+        year_month: 対象年月（YYYY-MM形式）。
+        tenant_id: ``X-Tenant-Id`` ヘッダーから取得したテナントID。
+        session: DBセッション。
+
+    Returns:
+        ShiftPlanDetailResponse、該当なければ null。
+    """
+    return shift_plan_import_service.get_shift_plan_by_year_month(
+        session, tenant_id, year_month
     )
 
 

--- a/backend/app/services/shift_plan_import_service.py
+++ b/backend/app/services/shift_plan_import_service.py
@@ -26,7 +26,12 @@ from app.models.models import (
     SlotTypeEnum,
     Worker,
 )
-from app.models.schemas import ShiftPlanImportResponse
+from app.models.schemas import (
+    ShiftAssignmentDetail,
+    ShiftPlanDetailResponse,
+    ShiftPlanImportResponse,
+    ShiftSlotDetail,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -471,3 +476,78 @@ def _normalize_json_rows(
             {"date": shift_date, "slot_type": slot_type, "worker_nos": worker_nos}
         )
     return result
+
+
+def get_shift_plan_by_year_month(
+    session: Session,
+    tenant_id: str,
+    year_month: str,
+) -> ShiftPlanDetailResponse | None:
+    """対象年月のシフトプランをスロット・アサイン情報込みで返す.
+
+    同一年月に複数プランが存在する場合は最新（作成日時降順）の1件を返す。
+
+    Args:
+        session: SQLModelセッション。
+        tenant_id: テナントID。
+        year_month: 対象年月（YYYY-MM形式）。
+
+    Returns:
+        ShiftPlanDetailResponse、該当なければ None。
+    """
+    plan = session.exec(
+        select(ShiftPlan)
+        .where(
+            ShiftPlan.tenant_id == tenant_id,  # type: ignore[arg-type]
+            ShiftPlan.target_year_month == year_month,  # type: ignore[arg-type]
+        )
+        .order_by(ShiftPlan.created_at.desc())  # type: ignore[attr-defined]
+        .limit(1)
+    ).first()
+
+    if plan is None:
+        return None
+
+    slots = session.exec(
+        select(ShiftSlot).where(
+            ShiftSlot.plan_id == plan.id,  # type: ignore[arg-type]
+            ShiftSlot.tenant_id == tenant_id,
+        )
+    ).all()
+
+    slot_ids = [s.id for s in slots]
+    all_assignments = (
+        session.exec(
+            select(ShiftAssignment).where(
+                ShiftAssignment.slot_id.in_(slot_ids),  # type: ignore[attr-defined]
+                ShiftAssignment.tenant_id == tenant_id,
+            )
+        ).all()
+        if slot_ids
+        else []
+    )
+
+    assignments_by_slot: dict[uuid.UUID, list[ShiftAssignmentDetail]] = {}
+    for a in all_assignments:
+        sid = cast(uuid.UUID, a.slot_id)
+        assignments_by_slot.setdefault(sid, []).append(
+            ShiftAssignmentDetail.model_validate(a)
+        )
+
+    slot_details = [
+        ShiftSlotDetail(
+            id=cast(uuid.UUID, s.id),
+            date=s.date,  # type: ignore[arg-type]
+            slot_type=cast(SlotTypeEnum, s.slot_type),
+            assignments=assignments_by_slot.get(cast(uuid.UUID, s.id), []),
+        )
+        for s in slots
+    ]
+
+    return ShiftPlanDetailResponse(
+        id=cast(uuid.UUID, plan.id),
+        title=cast(str, plan.title),
+        target_year_month=cast(str, plan.target_year_month),
+        status=cast(PlanStatusEnum, plan.status),
+        slots=slot_details,
+    )

--- a/docs/bug-duplicate-shift-plan-on-reimport-issue.md
+++ b/docs/bug-duplicate-shift-plan-on-reimport-issue.md
@@ -1,0 +1,55 @@
+# Bug: 同一年月への再インポートで ShiftPlan レコードが重複蓄積する
+
+**種別**: Bug  
+**優先度**: High  
+**影響範囲**: `backend/app/services/shift_plan_import_service.py`
+
+---
+
+## 問題の概要
+
+`import_shift_plan()` は、同一テナント・同一年月のデータが既に存在するかを確認せずに毎回 `ShiftPlan` レコードを新規生成します。
+そのため、同じ月のCSVを複数回インポートすると `shift_plans` テーブルにレコードが際限なく積み上がります。
+
+```python
+# 現在の実装（問題あり）
+plan = ShiftPlan(
+    id=uuid.uuid4(),
+    ...
+    target_year_month=target_year_month,  # 重複チェックなし
+)
+session.add(plan)
+```
+
+## 何が問題か
+
+`get_shift_plan_by_year_month()` は `ORDER BY created_at DESC LIMIT 1` で最新1件を取得するため、**画面上は最新データが表示される**。しかし、古いレコード（`shift_slots` / `shift_assignments` を含む）はDBに残り続けます。
+
+- 大量インポートが発生した場合、DBが不要データで肥大化する
+- 過去プランの DELETE / RLS 設計に影響が出る
+- テナント間でのデータ分離ポリシーを確認・監査する際にノイズになる
+
+## 修正方法
+
+インポート時に同一テナント・同一年月の既存プランを削除（または上書き）してから新規作成する。
+
+```python
+# 既存プランを削除してから作成（推奨）
+existing_plan = session.exec(
+    select(ShiftPlan).where(
+        ShiftPlan.tenant_id == tenant_id,
+        ShiftPlan.target_year_month == target_year_month,
+    )
+).first()
+
+if existing_plan is not None:
+    session.delete(existing_plan)
+    session.flush()
+```
+
+`shift_slots` / `shift_assignments` は `ondelete="CASCADE"` 設定済みのため、`ShiftPlan` を削除するだけで関連レコードも自動削除されます。
+
+## 補足
+
+- `shift_slots.plan_id` → `ForeignKey("shift_plans.id", ondelete="CASCADE")` ✅
+- `shift_assignments.slot_id` → `ForeignKey("shift_slots.id", ondelete="CASCADE")` ✅

--- a/docs/bug-side-effect-in-state-updater-issue.md
+++ b/docs/bug-side-effect-in-state-updater-issue.md
@@ -1,0 +1,63 @@
+# Bug: React state updater 内でのサイドエフェクト呼び出し
+
+**種別**: Bug  
+**優先度**: High  
+**影響範囲**: `frontend/components/shift-calendar/ShiftCalendar.tsx`
+
+---
+
+## 問題の概要
+
+`ShiftCalendar.tsx` の `prevMonth` / `nextMonth` で、`setState` の関数型更新の **コールバック内** から `onYearMonthChange?.()` を呼び出しています。
+
+```typescript
+// 現在の実装（問題あり）
+const prevMonth = useCallback(() => {
+  if (month === 1) {
+    setYear((y) => { onYearMonthChange?.(y - 1, 12); return y - 1; }); // ❌ サイドエフェクト
+    setMonth(12);
+  } else {
+    setMonth((m) => { onYearMonthChange?.(year, m - 1); return m - 1; }); // ❌ サイドエフェクト
+  }
+}, [month, year, onYearMonthChange]);
+```
+
+## 何が問題か
+
+React の `setState` 関数型更新コールバック（`(prev) => next` 形式）は **純粋関数** でなければなりません。副作用（外部関数の呼び出し・状態更新・API呼び出しなど）を含めることは React の仕様違反であり、以下のリスクがあります。
+
+- **React 18 + Strict Mode** では state updater が開発環境で2回呼ばれるため、`onYearMonthChange` が2回実行される
+- `onYearMonthChange` の中で `setCalYear` / `setCalMonth` / `setViewMode` が呼ばれるため、不整合な状態遷移が起きる可能性がある
+
+## 修正方法
+
+`onYearMonthChange` の呼び出しを state updater の **外** に移動する。
+
+```typescript
+// 修正後
+const prevMonth = useCallback(() => {
+  if (month === 1) {
+    onYearMonthChange?.(year - 1, 12);
+    setYear((y) => y - 1);
+    setMonth(12);
+  } else {
+    onYearMonthChange?.(year, month - 1);
+    setMonth((m) => m - 1);
+  }
+}, [month, year, onYearMonthChange]);
+
+const nextMonth = useCallback(() => {
+  if (month === 12) {
+    onYearMonthChange?.(year + 1, 1);
+    setYear((y) => y + 1);
+    setMonth(1);
+  } else {
+    onYearMonthChange?.(year, month + 1);
+    setMonth((m) => m + 1);
+  }
+}, [month, year, onYearMonthChange]);
+```
+
+## 影響
+
+月ナビゲーション時に `page.tsx` 側の `calYear` / `calMonth` が2回更新されると、`useShiftPlan` の SWR フェッチも2回トリガーされ、不要なAPIリクエストが発生する。

--- a/docs/past-shift-plan-feature.md
+++ b/docs/past-shift-plan-feature.md
@@ -1,0 +1,121 @@
+# 過去シフトプラン参照・モード切り替え機能 仕様書
+
+## 概要
+
+CSVインポートで投入した過去シフトデータを、シフト枠カレンダー画面（`/shift-requirements`）でそのまま閲覧できる機能です。
+対象年月に過去インポートデータが存在する場合は「📋 過去シフト（閲覧専用）」タブを自動表示し、存在しない場合は従来の「✏️ シフト枠編集」モードで直接開きます。
+
+---
+
+## データモデルの関係
+
+過去シフトデータと現在のシフト要件データは **別テーブル** に存在します。
+
+| 目的 | テーブル群 |
+|------|-----------|
+| 過去シフトインポートデータ | `shift_plans` → `shift_slots` → `shift_assignments` |
+| 現在のシフト要件・アサイン | `shift_requirements` → `shift_requirement_assignments` |
+
+`POST /api/shift-plans/import` はインポートデータを `shift_plans` 系テーブルに書き込みます。
+`GET /api/shift-requirements/` は `shift_requirements` テーブルを読み取るため、両者は独立しています。
+
+---
+
+## API エンドポイント
+
+### 過去シフトプラン取得
+
+```
+GET /api/shift-plans/?year_month=YYYY-MM
+Header: X-Tenant-Id: <tenant_id>
+```
+
+**クエリパラメータ:**
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|-----|------|------|
+| `year_month` | string | ✅ | 対象年月（`YYYY-MM` 形式）例: `2025-06` |
+
+**レスポンス（プランあり）:**
+```json
+{
+  "id": "uuid",
+  "title": "2025-06 インポート",
+  "target_year_month": "2025-06",
+  "status": "published",
+  "slots": [
+    {
+      "id": "uuid",
+      "date": "2025-06-01T00:00:00",
+      "slot_type": "weekday_night",
+      "assignments": [
+        {
+          "id": "uuid",
+          "worker_id": "uuid",
+          "is_manual_override": true
+        }
+      ]
+    }
+  ]
+}
+```
+
+**レスポンス（プランなし）:**
+```json
+null
+```
+
+同一年月に複数のプランが存在する場合は、作成日時が最新のものを返します。
+
+---
+
+## フロントエンド動作仕様
+
+### 表示モードの自動切り替え
+
+`/shift-requirements` ページは、カレンダーが表示している年月をもとに `GET /api/shift-plans/` を呼び出し、結果に応じてモードを自動決定します。
+
+| 状態 | デフォルト表示モード |
+|------|---------------------|
+| 過去プランが存在する | 「📋 過去シフト」（読み取り専用） |
+| 過去プランが存在しない | 「✏️ シフト枠編集」 |
+
+ユーザーはタブをクリックすることでいつでも手動で切り替えられます。
+月ナビゲーション（前月 / 翌月）で年月が変わると、モード選択はリセットされ再び自動判定が行われます。
+
+### 読み取り専用モード（pastPlan モード）
+
+- カレンダー上の各スロットにドラッグ＆ドロップは行えない
+- 保存ボタンは非表示
+- 各スロットにはアサインされたワーカー名のみ表示される
+
+---
+
+## 実装ファイル一覧
+
+### バックエンド
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `backend/app/models/schemas.py` | `ShiftAssignmentDetail`, `ShiftSlotDetail`, `ShiftPlanDetailResponse` スキーマを追加 |
+| `backend/app/services/shift_plan_import_service.py` | `get_shift_plan_by_year_month()` 関数を追加 |
+| `backend/app/routers/shift_plans.py` | `GET /api/shift-plans/` エンドポイントを追加 |
+
+### フロントエンド
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `frontend/types/shiftPlan.ts` | `ShiftPlanDetail`, `ShiftSlotDetail`, `ShiftAssignmentDetail` 型を追加 |
+| `frontend/hooks/useShiftPlan.ts` | 新規作成。指定年月の過去プランを SWR で取得 |
+| `frontend/components/shift-calendar/ShiftSlot.tsx` | `readOnly` プロップを追加。true 時はドロップゾーンの代わりにワーカー名を表示 |
+| `frontend/components/shift-calendar/CalendarCell.tsx` | `readOnly` プロップを追加し `ShiftSlot` へ伝播 |
+| `frontend/components/shift-calendar/ShiftCalendar.tsx` | `pastPlan`, `readOnly`, `onYearMonthChange` プロップを追加 |
+| `frontend/app/shift-requirements/page.tsx` | `useShiftPlan` フックを統合し、モード切り替えタブ UI を追加 |
+
+---
+
+## 制約・注意事項
+
+- `shift_requirements` テーブルにデータがない状態で `GET /api/shift-requirements/` を呼び出しても空配列が返るのは仕様通りです。過去インポートデータは `shift_plans` 系テーブルに格納されています。
+- `GET /api/shift-plans/` は `shift_requirements` とは独立しているため、両者のデータが同時に存在する場合でも、それぞれ別のエンドポイントから取得されます。
+- インポート済みデータの編集・上書きはこの機能のスコープ外です。過去データを修正する場合は再インポートが必要です。

--- a/docs/ux-calendar-flicker-on-month-change-issue.md
+++ b/docs/ux-calendar-flicker-on-month-change-issue.md
@@ -1,0 +1,72 @@
+# UX: 月ナビゲーション時にカレンダーが planLoading でちらつく
+
+**種別**: UX 改善  
+**優先度**: Medium  
+**影響範囲**: `frontend/app/shift-requirements/page.tsx`
+
+---
+
+## 問題の概要
+
+`page.tsx` の描画分岐は `isLoading || planLoading` をまとめてチェックしており、月ナビゲーション後に `useShiftPlan` の再フェッチが発生するたびに **カレンダー全体がローディング表示に切り替わります**。
+
+```tsx
+// 現在の実装（問題あり）
+{isLoading || planLoading ? (
+  <div>読み込み中...</div>
+) : activeDept ? (
+  <ShiftCalendar ... />
+) : ...}
+```
+
+## 何が問題か
+
+`isLoading`（部門・ルール）は初回のみ発生しますが、`planLoading`（過去プラン）は月を切り替えるたびに `true` になります。
+結果として、月ナビゲーションのたびにカレンダーが消えて「読み込み中...」が表示され、UX が劣化します。
+
+## 修正方法
+
+`planLoading` を **カレンダーの表示制御から分離** し、カレンダー自体は継続表示しながらタブやデータの切り替えだけをローディング中として処理する。
+
+```tsx
+// 修正後
+{isLoading ? (
+  <div>読み込み中...</div>
+) : activeDept ? (
+  <>
+    {/* 表示モード切り替えタブ */}
+    {!planLoading && shiftPlan && (
+      <div className="flex gap-1 mb-4 border-b border-gray-200">
+        {/* タブ */}
+      </div>
+    )}
+    {planLoading && (
+      <div className="text-xs text-gray-400 mb-2">過去データを確認中...</div>
+    )}
+    <ShiftCalendar
+      department={activeDept}
+      pastPlan={effectiveMode === "past" ? shiftPlan : null}
+      readOnly={effectiveMode === "past"}
+      onYearMonthChange={handleYearMonthChange}
+    />
+  </>
+) : ...}
+```
+
+## 補足
+
+SWR は `keepPreviousData: true` オプションを使うことでフェッチ中も前のデータを保持できます。`useShiftPlan.ts` の SWR オプションに追加することも有効です。
+
+```typescript
+// useShiftPlan.ts
+const { data, error, isLoading } = useSWR<ShiftPlanDetail | null>(
+  swrKey,
+  fetcher,
+  {
+    revalidateOnFocus: false,
+    keepPreviousData: true, // 追加
+  },
+);
+```
+
+ただし `keepPreviousData` を使うと月切り替え直後に前月のデータが表示され続けるため、`page.tsx` 側で月変更直後に `viewMode` をリセットする既存のロジックとの組み合わせに注意が必要です。

--- a/frontend/app/shift-requirements/page.tsx
+++ b/frontend/app/shift-requirements/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, useCallback } from "react";
 import Link from "next/link";
 
 import { SciFiButton } from "@/components/ui/SciFiButton";
@@ -9,13 +9,37 @@ import { ImportShiftPlanModal } from "@/components/shift-import/ImportShiftPlanM
 import { ShiftCalendar } from "@/components/shift-calendar/ShiftCalendar";
 import { useDepartments } from "@/hooks/useDepartments";
 import { useShiftRules } from "@/hooks/useShiftRules";
+import { useShiftPlan } from "@/hooks/useShiftPlan";
 import type { Department } from "@/types/department";
 
+type ViewMode = "past" | "edit";
+
 export default function ShiftRequirementsPage() {
+  const today = new Date();
   const { departments, isLoading: deptsLoading } = useDepartments();
   const { rules, isLoading: rulesLoading } = useShiftRules();
   const [activeDeptId, setActiveDeptId] = useState<string | null>(null);
   const [showImportModal, setShowImportModal] = useState(false);
+
+  // カレンダーが表示中の年月（ShiftCalendar の月ナビと同期）
+  const [calYear, setCalYear] = useState(today.getFullYear());
+  const [calMonth, setCalMonth] = useState(today.getMonth() + 1);
+
+  const handleYearMonthChange = useCallback((y: number, m: number) => {
+    setCalYear(y);
+    setCalMonth(m);
+    // 月が変わったら表示モードをリセット（pastPlan の存在で自動判定させる）
+    setViewMode(null);
+  }, []);
+
+  // 現在表示中の年月の過去プランを取得
+  const { shiftPlan, isLoading: planLoading } = useShiftPlan({ year: calYear, month: calMonth });
+
+  // null = 未選択（pastPlan の有無で自動決定）、それ以外はユーザーが手動選択済み
+  const [viewMode, setViewMode] = useState<ViewMode | null>(null);
+
+  // 実際に使うモード: ユーザーが選択していれば従う、未選択なら pastPlan があれば "past"、なければ "edit"
+  const effectiveMode: ViewMode = viewMode ?? (shiftPlan ? "past" : "edit");
 
   const isLoading = deptsLoading || rulesLoading;
 
@@ -71,13 +95,46 @@ export default function ShiftRequirementsPage() {
           </div>
         )}
 
+        {/* 表示モード切り替えタブ（過去データが存在するときのみ表示） */}
+        {!isLoading && !planLoading && shiftPlan && (
+          <div className="flex gap-1 mb-4 border-b border-gray-200">
+            <button
+              onClick={() => setViewMode("past")}
+              className={[
+                "px-4 py-2 text-sm font-medium border-b-2 transition-colors",
+                effectiveMode === "past"
+                  ? "border-blue-500 text-blue-600"
+                  : "border-transparent text-gray-500 hover:text-gray-700",
+              ].join(" ")}
+            >
+              📋 過去シフト（{shiftPlan.target_year_month}）
+            </button>
+            <button
+              onClick={() => setViewMode("edit")}
+              className={[
+                "px-4 py-2 text-sm font-medium border-b-2 transition-colors",
+                effectiveMode === "edit"
+                  ? "border-blue-500 text-blue-600"
+                  : "border-transparent text-gray-500 hover:text-gray-700",
+              ].join(" ")}
+            >
+              ✏️ シフト枠編集
+            </button>
+          </div>
+        )}
+
         {/* カレンダー */}
-        {isLoading ? (
+        {isLoading || planLoading ? (
           <div className="flex items-center justify-center py-20 text-gray-400 text-sm">
             読み込み中...
           </div>
         ) : activeDept ? (
-          <ShiftCalendar department={activeDept} />
+          <ShiftCalendar
+            department={activeDept}
+            pastPlan={effectiveMode === "past" ? shiftPlan : null}
+            readOnly={effectiveMode === "past"}
+            onYearMonthChange={handleYearMonthChange}
+          />
         ) : (
           <div className="flex flex-col items-center justify-center py-20 text-gray-400 text-sm gap-3">
             <p>シフト対象部門が設定されていません。</p>

--- a/frontend/components/shift-calendar/CalendarCell.tsx
+++ b/frontend/components/shift-calendar/CalendarCell.tsx
@@ -42,6 +42,7 @@ interface CalendarCellProps {
     workerId: string | null,
   ) => void;
   onSlotFocus: (dateStr: string, slotType: SlotType) => void;
+  readOnly?: boolean;
 }
 
 /** 1日分のカレンダーセルコンポーネント */
@@ -59,6 +60,7 @@ export function CalendarCell({
   isWorkerAvailable,
   onWorkerChange,
   onSlotFocus,
+  readOnly = false,
 }: CalendarCellProps) {
   const dayOfWeek = date.getDay();
   const dayNum = date.getDate();
@@ -117,6 +119,7 @@ export function CalendarCell({
               isWorkerAvailable={isWorkerAvailable}
               onWorkerChange={(idx, wid) => onWorkerChange(slotType, idx, wid)}
               onSlotFocus={onSlotFocus}
+              readOnly={readOnly}
             />
           ))}
         </div>
@@ -143,6 +146,7 @@ export function CalendarCell({
               isWorkerAvailable={isWorkerAvailable}
               onWorkerChange={(idx, wid) => onWorkerChange(slotType, idx, wid)}
               onSlotFocus={onSlotFocus}
+              readOnly={readOnly}
             />
           ))}
         </div>

--- a/frontend/components/shift-calendar/ShiftCalendar.tsx
+++ b/frontend/components/shift-calendar/ShiftCalendar.tsx
@@ -32,6 +32,7 @@ import type {
   ShiftRequirementCreate,
 } from "@/types/shiftRequirement";
 import type { Department } from "@/types/department";
+import type { ShiftPlanDetail } from "@/types/shiftPlan";
 import { useShiftValidation, buildSlotKey } from "@/hooks/useShiftValidation";
 import type { ValidationViolation } from "@/utils/shiftValidators";
 import {
@@ -49,10 +50,16 @@ const DEFAULT_HEADCOUNT = 2;
 
 interface ShiftCalendarProps {
   department: Department;
+  /** 過去インポートデータ。指定時はそのデータでカレンダーを初期化する */
+  pastPlan?: ShiftPlanDetail | null;
+  /** true の場合、編集・保存操作を無卒化する */
+  readOnly?: boolean;
+  /** 年月切り替え時のコールバック */
+  onYearMonthChange?: (year: number, month: number) => void;
 }
 
 /** 月間シフト枠カレンダーコンポーネント */
-export function ShiftCalendar({ department }: ShiftCalendarProps) {
+export function ShiftCalendar({ department, pastPlan, readOnly = false, onYearMonthChange }: ShiftCalendarProps) {
   const today = new Date();
   const [year, setYear] = useState(today.getFullYear());
   const [month, setMonth] = useState(today.getMonth() + 1);
@@ -133,36 +140,53 @@ export function ShiftCalendar({ department }: ShiftCalendarProps) {
       }
     }
 
-    // バックエンドから取得したシフト枠データで上書き
-    const monthPrefix = `${year}-${String(month).padStart(2, "0")}`;
-    for (const req of shiftRequirements) {
-      if (
-        !req.shift_date.startsWith(monthPrefix) ||
-        req.department_id !== department.id
-      )
-        continue;
-      const dateStr = req.shift_date;
-      if (!newState[dateStr]) continue;
-      const headcount = req.required_headcount;
-
-      // 保存済みのワーカー選択を復元する
-      const savedWorkerIds = req.assignments.map((a) => a.worker_id);
-      const workerSelections: (string | null)[] = Array(headcount).fill(null) as null[];
-      for (let i = 0; i < Math.min(savedWorkerIds.length, headcount); i++) {
-        workerSelections[i] = savedWorkerIds[i];
+    if (pastPlan) {
+      // 過去プランデータでカレンダーを上書きする
+      const monthPrefix = `${year}-${String(month).padStart(2, "0")}`;
+      for (const slot of pastPlan.slots) {
+        const dateStr = slot.date.slice(0, 10); // ISO datetime から YYYY-MM-DD を抽出
+        if (!dateStr.startsWith(monthPrefix)) continue;
+        if (!newState[dateStr]) continue;
+        const workerIds = slot.assignments.map((a) => a.worker_id);
+        newState[dateStr][slot.slot_type as SlotType] = {
+          slot_type: slot.slot_type as SlotType,
+          required_headcount: workerIds.length || DEFAULT_HEADCOUNT,
+          workerSelections: workerIds.length > 0 ? workerIds : Array(DEFAULT_HEADCOUNT).fill(null) as null[],
+          isDirty: false,
+        };
       }
+    } else {
+      // バックエンドから取得したシフト枠データで上書き
+      const monthPrefix = `${year}-${String(month).padStart(2, "0")}`;
+      for (const req of shiftRequirements) {
+        if (
+          !req.shift_date.startsWith(monthPrefix) ||
+          req.department_id !== department.id
+        )
+          continue;
+        const dateStr = req.shift_date;
+        if (!newState[dateStr]) continue;
+        const headcount = req.required_headcount;
 
-      newState[dateStr][req.slot_type] = {
-        requirementId: req.id,
-        slot_type: req.slot_type,
-        required_headcount: headcount,
-        workerSelections,
-        isDirty: false,
-      };
+        // 保存済みのワーカー選択を復元する
+        const savedWorkerIds = req.assignments.map((a) => a.worker_id);
+        const workerSelections: (string | null)[] = Array(headcount).fill(null) as null[];
+        for (let i = 0; i < Math.min(savedWorkerIds.length, headcount); i++) {
+          workerSelections[i] = savedWorkerIds[i];
+        }
+
+        newState[dateStr][req.slot_type] = {
+          requirementId: req.id,
+          slot_type: req.slot_type,
+          required_headcount: headcount,
+          workerSelections,
+          isDirty: false,
+        };
+      }
     }
 
     setCalendarState(newState);
-  }, [shiftRequirements, calendarGrid, holidaySet, year, month, department.id]);
+  }, [shiftRequirements, pastPlan, calendarGrid, holidaySet, year, month, department.id]);
 
   /** ワーカー選択変更ハンドラ */
   const handleWorkerChange = useCallback(
@@ -317,21 +341,21 @@ export function ShiftCalendar({ department }: ShiftCalendarProps) {
 
   const prevMonth = useCallback(() => {
     if (month === 1) {
-      setYear((y) => y - 1);
+      setYear((y) => { onYearMonthChange?.(y - 1, 12); return y - 1; });
       setMonth(12);
     } else {
-      setMonth((m) => m - 1);
+      setMonth((m) => { onYearMonthChange?.(year, m - 1); return m - 1; });
     }
-  }, [month]);
+  }, [month, year, onYearMonthChange]);
 
   const nextMonth = useCallback(() => {
     if (month === 12) {
-      setYear((y) => y + 1);
+      setYear((y) => { onYearMonthChange?.(y + 1, 1); return y + 1; });
       setMonth(1);
     } else {
-      setMonth((m) => m + 1);
+      setMonth((m) => { onYearMonthChange?.(year, m + 1); return m + 1; });
     }
-  }, [month]);
+  }, [month, year, onYearMonthChange]);
 
   const hasDirtySlots = useMemo(() => {
     for (const dayState of Object.values(calendarState)) {
@@ -373,15 +397,17 @@ export function ShiftCalendar({ department }: ShiftCalendarProps) {
                 <SciFiButton variant="secondary" size="sm" onClick={nextMonth}>
                   翌月 &gt;&gt;
                 </SciFiButton>
-                <SciFiButton
-                  variant="primary"
-                  size="sm"
-                  onClick={handleSave}
-                  loading={isSaving}
-                  disabled={!hasDirtySlots}
-                >
-                  保存
-                </SciFiButton>
+                {!readOnly && (
+                  <SciFiButton
+                    variant="primary"
+                    size="sm"
+                    onClick={handleSave}
+                    loading={isSaving}
+                    disabled={!hasDirtySlots}
+                  >
+                    保存
+                  </SciFiButton>
+                )}
               </div>
             </div>
 
@@ -454,6 +480,7 @@ export function ShiftCalendar({ department }: ShiftCalendarProps) {
                           handleWorkerChange(dateStr, slotType, idx2, wid)
                         }
                         onSlotFocus={handleSlotFocus}
+                        readOnly={readOnly}
                       />
                     );
                   })}

--- a/frontend/components/shift-calendar/ShiftSlot.tsx
+++ b/frontend/components/shift-calendar/ShiftSlot.tsx
@@ -22,6 +22,8 @@ interface ShiftSlotProps {
   /** フォーカス時（スロット選択）コールバック */
   onSlotFocus: (dateStr: string, slotType: SlotType) => void;
   onWorkerChange: (index: number, workerId: string | null) => void;
+  /** 読み取り専用モード（過去データ表示時）。true の場合、ドロップゾーンを非活性化する */
+  readOnly?: boolean;
 }
 
 /** 1スロット分のコンポーネント（DnDドロップゾーン） */
@@ -36,6 +38,7 @@ export function ShiftSlot({
   isWorkerAvailable,
   onSlotFocus,
   onWorkerChange,
+  readOnly = false,
 }: ShiftSlotProps) {
   const label = SLOT_TYPE_LABELS[slotType];
   const hasError = violations.some((v) => v.severity === "error");
@@ -55,21 +58,33 @@ export function ShiftSlot({
         </span>
         <ValidationBadge violations={violations} />
       </div>
-      {workerSelections.map((workerId, idx) => (
-        <ShiftSlotDropZone
-          key={idx}
-          dateStr={dateStr}
-          slotType={slotType}
-          index={idx}
-          workerId={workerId}
-          workers={workers}
-          departments={departments}
-          skillRanks={skillRanks}
-          isDropAllowed={isWorkerAvailable}
-          onClear={() => onWorkerChange(idx, null)}
-          onFocus={() => onSlotFocus(dateStr, slotType)}
-        />
-      ))}
+      {readOnly
+        ? workerSelections.map((workerId, idx) => {
+            const worker = workerId ? workers.find((w) => w.id === workerId) : null;
+            return (
+              <div
+                key={idx}
+                className="text-[10px] text-center rounded px-1 py-0.5 bg-gray-50 text-gray-600 border border-gray-200 truncate"
+              >
+                {worker ? worker.name : <span className="text-gray-300">—</span>}
+              </div>
+            );
+          })
+        : workerSelections.map((workerId, idx) => (
+            <ShiftSlotDropZone
+              key={idx}
+              dateStr={dateStr}
+              slotType={slotType}
+              index={idx}
+              workerId={workerId}
+              workers={workers}
+              departments={departments}
+              skillRanks={skillRanks}
+              isDropAllowed={isWorkerAvailable}
+              onClear={() => onWorkerChange(idx, null)}
+              onFocus={() => onSlotFocus(dateStr, slotType)}
+            />
+          ))}
     </div>
   );
 }

--- a/frontend/hooks/useShiftPlan.ts
+++ b/frontend/hooks/useShiftPlan.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useAuth, useOrganization } from "@clerk/nextjs";
+import { useMemo } from "react";
+import useSWR from "swr";
+
+import { fetcher } from "@/utils/fetcher";
+import type { ShiftPlanDetail } from "@/types/shiftPlan";
+
+const SHIFT_PLANS_PATH = "/api/shift-plans/";
+
+type UseShiftPlanOptions = {
+  year: number;
+  month: number;
+};
+
+type UseShiftPlanResult = {
+  shiftPlan: ShiftPlanDetail | null;
+  isLoading: boolean;
+  error: unknown;
+};
+
+/** 指定年月のシフトプラン（過去インポートデータ）を取得するカスタムフック */
+export function useShiftPlan({ year, month }: UseShiftPlanOptions): UseShiftPlanResult {
+  const { getToken } = useAuth();
+  const { organization } = useOrganization();
+  const tenantId = organization?.id ?? null;
+
+  const yearMonth = `${year}-${String(month).padStart(2, "0")}`;
+
+  const path = `${SHIFT_PLANS_PATH}?year_month=${yearMonth}`;
+
+  const swrKey = useMemo<[string, null, string | null] | null>(
+    () => (tenantId ? [path, null, tenantId] : null),
+    [tenantId, path],
+  );
+
+  const { data, error, isLoading } = useSWR<ShiftPlanDetail | null>(
+    swrKey,
+    async ([p, , tid]: [string, null, string | null]) => {
+      const token = await getToken();
+      return fetcher<ShiftPlanDetail | null>([p, token, tid]);
+    },
+    {
+      revalidateOnFocus: false,
+    },
+  );
+
+  return {
+    shiftPlan: data ?? null,
+    isLoading,
+    error,
+  };
+}

--- a/frontend/types/shiftPlan.ts
+++ b/frontend/types/shiftPlan.ts
@@ -11,3 +11,28 @@ export interface ShiftPlanImportResponse {
   assignments_created: number;
   skipped_worker_ids: string[];
 }
+
+/** シフトアサイン詳細（ShiftPlanDetail 内で使用） */
+export interface ShiftAssignmentDetail {
+  id: string;
+  worker_id: string;
+  is_manual_override: boolean;
+}
+
+/** シフトスロット詳細（ShiftPlanDetail 内で使用） */
+export interface ShiftSlotDetail {
+  id: string;
+  /** ISO 8601 datetime 文字列 */
+  date: string;
+  slot_type: string;
+  assignments: ShiftAssignmentDetail[];
+}
+
+/** シフトプラン詳細（スロット・アサイン情報を含む） */
+export interface ShiftPlanDetail {
+  id: string;
+  title: string;
+  target_year_month: string;
+  status: PlanStatus;
+  slots: ShiftSlotDetail[];
+}


### PR DESCRIPTION
過去のシフトプランを取得するためのAPIエンドポイントを追加し、フロントエンドでの表示機能を実装。シフトプランの詳細情報を表現するスキーマを追加し、読み取り専用モードを実装。関連するバグの詳細も文書化。