### PR TITLE
役職除外チェック機能の追加と関連する型の拡張

### DIFF
--- a/backend/app/services/shift_validation_service.py
+++ b/backend/app/services/shift_validation_service.py
@@ -623,11 +623,13 @@ def _check_position_exclusion(
     requirement: ShiftRequirement,
     workers: list[Worker],
 ) -> list[ValidationViolationItem]:
-    """ルール7: 役職除外チェック（長期休暇期間中の除外フラグを持つ役職のアサイン禁止）."""
+    """ルール7: 役職除外チェック.
+
+    - is_excluded_from_all_shifts=True の役職はシフト種別に関わらず全アサイン禁止。
+    - 長期休暇期間中は、休暇種別に応じた除外フラグも評価する。
+    """
     shift_date: date = requirement.shift_date  # type: ignore[assignment]
     period = get_period_for_date(session, tenant_id, shift_date)
-    if period is None:
-        return []
 
     violations: list[ValidationViolationItem] = []
     for worker in workers:
@@ -641,7 +643,24 @@ def _check_position_exclusion(
         ).first()
         if position is None:
             continue
-        if is_holiday_type_excluded_by_position(period.holiday_type, position):  # type: ignore[arg-type]
+        # is_excluded_from_all_shifts は長期休暇期間外でも適用する
+        if position.is_excluded_from_all_shifts:
+            violations.append(
+                ValidationViolationItem(
+                    code="POSITION_EXCLUDED",
+                    severity="error",
+                    message=(
+                        f"{worker.name} の役職（{position.name}）は"
+                        f"全シフトへのアサインが除外されています"
+                    ),
+                    worker_ids=[str(worker.id)],
+                )
+            )
+            continue
+        # 長期休暇期間中は休暇種別ごとの除外フラグを評価する
+        if period is not None and is_holiday_type_excluded_by_position(
+            cast(LongHolidayTypeEnum, period.holiday_type), position
+        ):  # type: ignore[arg-type]
             violations.append(
                 ValidationViolationItem(
                     code="POSITION_EXCLUDED",

--- a/frontend/components/shift-calendar/ShiftCalendar.tsx
+++ b/frontend/components/shift-calendar/ShiftCalendar.tsx
@@ -145,6 +145,7 @@ export function ShiftCalendar({ department, year, month, pastPlan, readOnly = fa
     /* annualLimits= */ annualLimits,
     employmentTypes,
     customRules,
+    positions,
   );
 
   const holidayMap = useMemo(() => getHolidayMap(year, month), [year, month]);
@@ -180,6 +181,7 @@ export function ShiftCalendar({ department, year, month, pastPlan, readOnly = fa
     minIntervalDays,
     prevMonthDatesByWorker,
     employmentTypeMap,
+    positions,
     customRules,
   });
 

--- a/frontend/components/shift-calendar/WorkerListPanel.tsx
+++ b/frontend/components/shift-calendar/WorkerListPanel.tsx
@@ -111,6 +111,7 @@ export function WorkerListPanel({
       minIntervalDays,
       prevMonthDatesByWorker,
       employmentTypeMap,
+      positions,
       customRules,
     });
 

--- a/frontend/hooks/useAvailableWorkers.ts
+++ b/frontend/hooks/useAvailableWorkers.ts
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 
 import type { CustomRule } from "@/types/customRule";
 import type { EmploymentType } from "@/types/employmentType";
+import type { Position } from "@/types/position";
 import type { CalendarState, SlotType } from "@/types/shiftRequirement";
 import type { AnnualShiftLimitsConfig, ShiftRulesConfig } from "@/types/shiftRules";
 import type { TenantSkillRank } from "@/types/skillRank";
@@ -72,6 +73,8 @@ interface UseAvailableWorkersOptions {
   prevMonthDatesByWorker?: Record<string, string | null>;
   /** 雇用形態マップ（employment_type_id → EmploymentType）。allowed_slot_types フィルタリングに使用 */
   employmentTypeMap?: Map<string, EmploymentType>;
+  /** 役職リスト。is_excluded_from_all_shifts=true のWorkerを除外するために使用 */
+  positions?: Position[];
   /** カスタムルールリスト。is_assign_prohibited=true のWorkerを除外、allowed_slot_types によるスロット制限に使用 */
   customRules?: CustomRule[];
 }
@@ -94,6 +97,7 @@ export function useAvailableWorkers({
   minIntervalDays,
   prevMonthDatesByWorker,
   employmentTypeMap,
+  positions,
   customRules,
 }: UseAvailableWorkersOptions): AvailableWorkersResult {
   const skillRankMap = useMemo(
@@ -155,6 +159,12 @@ export function useAvailableWorkers({
     [customRules],
   );
 
+  /** 役職マップ（position_id → Position） */
+  const positionMap = useMemo(
+    () => positions ? new Map(positions.map((p) => [p.id, p])) : undefined,
+    [positions],
+  );
+
   const availableWorkers = useMemo(() => {
     if (showAll || slotType === null) return workers;
 
@@ -168,6 +178,12 @@ export function useAvailableWorkers({
         if (customRule?.allowed_slot_types && customRule.allowed_slot_types.length > 0) {
           if (!customRule.allowed_slot_types.includes(slotType)) return false;
         }
+      }
+
+      // 役職の is_excluded_from_all_shifts=true のWorkerを除外
+      if (positionMap && w.position_id) {
+        const position = positionMap.get(w.position_id);
+        if (position?.is_excluded_from_all_shifts) return false;
       }
 
       // すでにアサイン済みのWorkerは除外
@@ -362,7 +378,7 @@ export function useAvailableWorkers({
 
       return true;
     });
-  }, [workers, skillRankMap, assignedSet, allowSameDepartment, slotType, showAll, workerStatsMap, annualLimits, currentDateStr, minIntervalDays, prevMonthDatesByWorker, inProgressDataByWorker, rules, calendarState, employmentTypeMap, customRuleMap]);
+  }, [workers, skillRankMap, assignedSet, allowSameDepartment, slotType, showAll, workerStatsMap, annualLimits, currentDateStr, minIntervalDays, prevMonthDatesByWorker, inProgressDataByWorker, rules, calendarState, employmentTypeMap, positionMap, customRuleMap]);
 
   const isWorkerAvailable = useMemo(() => {
     const availableSet = new Set(availableWorkers.map((w) => w.id));

--- a/frontend/hooks/useShiftValidation.ts
+++ b/frontend/hooks/useShiftValidation.ts
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 
 import type { CustomRule } from "@/types/customRule";
 import type { EmploymentType } from "@/types/employmentType";
+import type { Position } from "@/types/position";
 import type { CalendarState, SlotType } from "@/types/shiftRequirement";
 import type { AnnualShiftLimitsConfig, ShiftRulesConfig } from "@/types/shiftRules";
 import type { TenantSkillRank } from "@/types/skillRank";
@@ -35,6 +36,8 @@ export type ValidationMap = Record<SlotKey, ValidationViolation[]>;
  * annualWorkerStats と annualLimits を渡すと、年間シフト回数上限チェックも実行される。
  *
  * customRules を渡すと、カスタムルールを雇用形態ルールより優先して適用する。
+ *
+ * positions を渡すと、is_excluded_from_all_shifts=true の役職を持つWorkerの違反を検出できる。
  */
 export function useShiftValidation(
   calendarState: CalendarState,
@@ -46,6 +49,7 @@ export function useShiftValidation(
   annualLimits?: AnnualShiftLimitsConfig,
   employmentTypes?: EmploymentType[],
   customRules?: CustomRule[],
+  positions?: Position[],
 ): ValidationMap {
   const workerMap = useMemo(
     () => new Map(workers.map((w) => [w.id, w])),
@@ -86,6 +90,12 @@ export function useShiftValidation(
     [customRules],
   );
 
+  /** 役職マップ（position_id → Position）。 */
+  const positionMap = useMemo(
+    () => positions ? new Map(positions.map((p) => [p.id, p])) : undefined,
+    [positions],
+  );
+
   const validationMap = useMemo(() => {
     const result: ValidationMap = {};
 
@@ -105,6 +115,7 @@ export function useShiftValidation(
           annualLimits,
           employmentTypeMap,
           customRuleMap,
+          positionMap,
         );
         if (violations.length > 0) {
           result[buildSlotKey(dateStr, slotType as SlotType)] = violations;
@@ -113,7 +124,7 @@ export function useShiftValidation(
     }
 
     return result;
-  }, [calendarState, workerMap, rules, skillRankMap, prevMonthDatesByWorker, workerStatsMap, annualLimits, employmentTypeMap, customRuleMap]);
+  }, [calendarState, workerMap, rules, skillRankMap, prevMonthDatesByWorker, workerStatsMap, annualLimits, employmentTypeMap, customRuleMap, positionMap]);
 
   return validationMap;
 }

--- a/frontend/utils/shiftValidators.ts
+++ b/frontend/utils/shiftValidators.ts
@@ -2,6 +2,7 @@
 // シフトバリデーションのための純粋関数群
 
 import type { EmploymentType } from "@/types/employmentType";
+import type { Position } from "@/types/position";
 import type { CalendarState, SlotType } from "@/types/shiftRequirement";
 import type { AnnualShiftLimitsConfig, ShiftRulesConfig } from "@/types/shiftRules";
 import type { TenantSkillRank } from "@/types/skillRank";
@@ -16,6 +17,7 @@ export type ValidationCode =
   | "WORK_INTERVAL" // 中9日未満の勤務間隔
   | "ASSIGN_PROHIBITED" // アサイン不可ルールによるアサイン禁止
   | "SPECIAL_EMPLOYMENT" // 特別雇用者の枠制限違反
+  | "POSITION_EXCLUDED" // 役職の全シフト除外フラグによるアサイン禁止
   | "NEW_HIRE_TENURE" // 採用後の期間制限
   | "TRANSFER_TENURE" // 事業本部間転入後の期間制限
   | "TOTAL_AGE_LIMIT" // スロット内ワーカーの合計年齢上限超過
@@ -300,6 +302,39 @@ export function validateAssignProhibited(
         code: "ASSIGN_PROHIBITED",
         severity: "error",
         message: `${worker.name} はアサイン不可ルールにより、いずれの枠にもアサインできません`,
+        workerIds: [worker.id],
+      });
+    }
+  }
+
+  return violations;
+}
+
+/**
+ * 役職除外チェック（POSITION_EXCLUDED）
+ * is_excluded_from_all_shifts=true の役職に紐付くワーカーは全スロットへのアサインを禁止する。
+ */
+export function validatePositionExclusion(
+  workers: readonly (string | null)[],
+  workerMap: Map<string, Worker>,
+  positionMap?: Map<string, Position>,
+): ValidationViolation[] {
+  if (!positionMap) return [];
+
+  const violations: ValidationViolation[] = [];
+  const assignedWorkers = workers
+    .filter((id): id is string => id !== null)
+    .map((id) => workerMap.get(id))
+    .filter((w): w is Worker => w !== undefined);
+
+  for (const worker of assignedWorkers) {
+    if (!worker.position_id) continue;
+    const position = positionMap.get(worker.position_id);
+    if (position?.is_excluded_from_all_shifts) {
+      violations.push({
+        code: "POSITION_EXCLUDED",
+        severity: "error",
+        message: `${worker.name} の役職（${position.name}）は全シフトへのアサインが除外されています`,
         workerIds: [worker.id],
       });
     }
@@ -805,6 +840,7 @@ export function validateSlot(
   annualLimits?: AnnualShiftLimitsConfig,
   employmentTypeMap?: Map<string, EmploymentType>,
   customRuleMap?: Map<string, { is_assign_prohibited?: boolean; allowed_slot_types: string[] | null; annual_limit_overrides: Record<string, number | null> | null }>,
+  positionMap?: Map<string, Position>,
 ): ValidationViolation[] {
   const assignedCount = workers.filter((id) => id !== null).length;
   if (assignedCount === 0) return [];
@@ -815,6 +851,7 @@ export function validateSlot(
     ...validateSkillRankA(workers, requiredHeadcount, workerMap, rules, skillRankMap),
     ...validateWorkInterval(dateStr, slotType, workers, calendarState, workerMap, rules, prevMonthDatesByWorker),
     ...validateAssignProhibited(workers, workerMap, customRuleMap),
+    ...validatePositionExclusion(workers, workerMap, positionMap),
     ...validateSpecialEmployment(slotType, workers, workerMap, rules, employmentTypeMap, customRuleMap),
     ...validateTenureRestriction(dateStr, workers, workerMap, rules),
     ...validateConsecutiveHolidays(dateStr, slotType, workers, calendarState, workerMap),


### PR DESCRIPTION
役職除外チェック機能を追加し、長期休暇期間中の除外フラグを評価するロジックを強化。Workerの役職リストを受け取るオプションを追加し、全シフト除外フラグを持つWorkerを除外する機能を実装。関連する型を拡張し、コンポーネントに役職リストを渡すプロパティを追加。